### PR TITLE
Add support to get the terraform configuration from multiple places

### DIFF
--- a/cloudsoft-terraform-template/cloudsoft-terraform-template.json
+++ b/cloudsoft-terraform-template/cloudsoft-terraform-template.json
@@ -1,61 +1,39 @@
 {
   "typeName": "Cloudsoft::Terraform::Template",
-  "description": "An example resource schema demonstrating some basic constructs and validation rules.",
-  "sourceUrl": "https://w.amazon.com/bin/view/AWS21/Design/Uluru/Onboarding_Guide/Development_Walkthrough",
-  "definitions": {
-    "MetricTransformationProperty": {
-      "type": "object",
-      "properties": {
-        "DefaultValue": {
-          "type": "number"
-        },
-        "MetricName": {
-          "type": "string"
-        },
-        "MetricNamespace": {
-          "type": "string"
-        },
-        "MetricValue": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "MetricName",
-        "MetricNamespace",
-        "MetricValue"
-      ]
-    }
-  },
+  "description": "The Cloudsoft::Terraform::Template resource creates and manages a terraform template, through an existing terraform server",
+  "sourceUrl": "https://github.com/cloudsoft/aws-cfn-connector-for-terraform",
   "properties": {
-    "FilterPattern": {
-      "description": "Pattern that Logs follows to interpret each entry in a log.",
+    "ConfigurationContent": {
+      "description": "Inlined terraform configuration, passed to the terraform server.",
       "type": "string"
     },
-    "LogGroupName": {
-      "description": "Existing log group that you want to associate with this filter",
-      "type": "string"
+    "ConfigurationUrl": {
+      "description": "Public HTTP URL of a terraform configuration. This will be downloaded and used by the terraform server.",
+      "type": "string",
+      "pattern": "^https?://.+$"
     },
-    "MetricTransformations": {
-      "description": "MetricTransformation",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/MetricTransformationProperty"
-      }
-    },
-    "FilterName": {
-      "type": "string"
+    "ConfigurationS3Path": {
+      "description": "S3 path object representing a terraform configuration. The current account must have access to this resource. This will be downloaded and used by the terraform server.",
+      "type": "string",
+      "pattern": "^s3://.+$"
     }
   },
-  "required": [
-    "FilterPattern",
-    "LogGroupName",
-    "MetricTransformations"
+  "oneOf": [
+    {
+      "$ref": "#/properties/ConfigurationContent"
+    },
+    {
+      "$ref": "#/properties/ConfigurationUrl"
+    },
+    {
+      "$ref": "#/properties/ConfigurationS3Path"
+    }
   ],
-  "readOnlyProperties": [
-    "/properties/FilterName"
-  ],
+  "required": [],
   "primaryIdentifier": [
-    "/properties/FilterName"
+    "/properties/ConfigurationContent",
+    "/properties/ConfigurationUrl",
+    "/properties/ConfigurationS3Path"
   ],
   "handlers": {
     "create": {

--- a/cloudsoft-terraform-template/pom.xml
+++ b/cloudsoft-terraform-template/pom.xml
@@ -26,6 +26,12 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.11.592</version>
+        </dependency>
+
         <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>
             <groupId>com.amazonaws.cloudformation</groupId>

--- a/cloudsoft-terraform-template/resource-role.yaml
+++ b/cloudsoft-terraform-template/resource-role.yaml
@@ -23,10 +23,10 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                - initech:CreateReport
-                - initech:DescribeReport
                 - initech:UpdateReport
+                - initech:CreateReport
                 - initech:ListReports
+                - initech:DescribeReport
                 - initech:DeleteReport
                 Resource: "*"
 Outputs:

--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/CreateHandler.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/CreateHandler.java
@@ -5,32 +5,8 @@ import com.amazonaws.cloudformation.proxy.Logger;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
 import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
-import com.amazonaws.services.logs.AWSLogs;
-import com.amazonaws.services.logs.AWSLogsClientBuilder;
-import com.amazonaws.services.logs.model.MetricTransformation;
-import com.amazonaws.services.logs.model.PutMetricFilterRequest;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-public class CreateHandler extends BaseHandler<CallbackContext> {
-
-    private List<MetricTransformation> getMetricTransformations(final ResourceModel model) {
-        List<MetricTransformationProperty> metricTransformations =
-                model.getMetricTransformations();
-        if (metricTransformations == null) {
-            return Collections.emptyList();
-        }
-        return metricTransformations.stream()
-                .map(mtp -> new MetricTransformation()
-                        .withMetricName(mtp.getMetricName())
-                        .withMetricValue(mtp.getMetricValue())
-                        .withMetricNamespace(mtp.getMetricNamespace())
-                        .withDefaultValue(mtp.getDefaultValue()))
-                .collect(Collectors.toList());
-    }
+public class CreateHandler extends TerraformBaseHandler<CallbackContext> {
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -41,19 +17,8 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
 
         ResourceModel model = request.getDesiredResourceState();
 
-        // Convert model to a form that works with your API
-        PutMetricFilterRequest putMetricFilterRequest = new PutMetricFilterRequest()
-                .withLogGroupName(model.getLogGroupName())
-                .withFilterPattern(model.getFilterPattern())
-                .withMetricTransformations(getMetricTransformations(model))
-                .withFilterName(model.getFilterName());
+        // TODO : put your code here
 
-        // Initialize client and send request
-        AWSLogs client = AWSLogsClientBuilder.standard().withRegion("eu-central-1").build();
-        // This is a minimal example, so we've kept it easy with no error handling
-        // You should add more error handling in real-world handlers
-        proxy.injectCredentialsAndInvoke(putMetricFilterRequest,
-                client::putMetricFilter);
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .resourceModel(model)
                 .status(OperationStatus.SUCCESS)

--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/DeleteHandler.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/DeleteHandler.java
@@ -9,7 +9,7 @@ import com.amazonaws.services.logs.AWSLogs;
 import com.amazonaws.services.logs.AWSLogsClientBuilder;
 import com.amazonaws.services.logs.model.DeleteMetricFilterRequest;
 
-public class DeleteHandler extends BaseHandler<CallbackContext> {
+public class DeleteHandler extends TerraformBaseHandler<CallbackContext> {
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -20,18 +20,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
 
         ResourceModel model = request.getDesiredResourceState();
 
-        // Convert model to a form that works with your API
-        DeleteMetricFilterRequest deleteMetricFilterRequest = new
-                DeleteMetricFilterRequest()
-                .withFilterName(model.getFilterName())
-                .withLogGroupName(model.getLogGroupName());
-
-        // Initialize client and send request
-        AWSLogs client = AWSLogsClientBuilder.standard().withRegion("eu-central-1").build();
-        // This is a minimal example, so we've kept it easy with no error handling
-        // You should add more error handling in real-world handlers
-        proxy.injectCredentialsAndInvoke(deleteMetricFilterRequest,
-                client::deleteMetricFilter);
+        // TODO : put your code here
 
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .resourceModel(model)

--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/ListHandler.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/ListHandler.java
@@ -9,7 +9,7 @@ import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ListHandler extends BaseHandler<CallbackContext> {
+public class ListHandler extends TerraformBaseHandler<CallbackContext> {
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/ReadHandler.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/ReadHandler.java
@@ -6,7 +6,7 @@ import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
 
-public class ReadHandler extends BaseHandler<CallbackContext> {
+public class ReadHandler extends TerraformBaseHandler<CallbackContext> {
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/TerraformBaseHandler.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/TerraformBaseHandler.java
@@ -1,0 +1,64 @@
+package io.cloudsoft.terraform.template;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public abstract class TerraformBaseHandler<T> extends BaseHandler<T> {
+
+    private AmazonS3 amazonS3;
+    private Pattern s3Pattern;
+
+    public TerraformBaseHandler() {
+        this(AmazonS3ClientBuilder.defaultClient());
+    }
+
+    public TerraformBaseHandler(AmazonS3 amazonS3) {
+        this.amazonS3 = amazonS3;
+        s3Pattern = Pattern.compile("^s3://([^/]*)/(.*)$");
+    }
+
+    protected String getConfiguration(ResourceModel model) {
+        if (model.getConfigurationContent() != null) {
+            return model.getConfigurationContent();
+        }
+
+        if (model.getConfigurationUrl() != null) {
+            try {
+                InputStream inputStream = null;
+                inputStream = new URL(model.getConfigurationUrl()).openStream();
+                return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new IllegalArgumentException(String.format("Failed to download file at %s", model.getConfigurationUrl()), e);
+            }
+        }
+
+        if (model.getConfigurationS3Path() != null) {
+            Matcher matcher = s3Pattern.matcher(model.getConfigurationS3Path());
+            if (!matcher.find()) {
+                throw new IllegalArgumentException(String.format("Invalid S3 path %s", model.getConfigurationS3Path()));
+            }
+
+            String bucket = matcher.group(1);
+            String key = matcher.group(2);
+
+            try {
+                S3Object templateObject = amazonS3.getObject(new GetObjectRequest(bucket, key));
+                return IOUtils.toString(templateObject.getObjectContent(), StandardCharsets.UTF_8);
+            } catch (Exception e) {
+                throw new IllegalArgumentException(String.format("Failed to get S3 file at %s", model.getConfigurationS3Path()), e);
+            }
+        }
+
+        throw new IllegalStateException("Missing one of the template properties");
+    }
+}

--- a/cloudsoft-terraform-template/src/test/java/io/cloudsoft/terraform/template/TerraformBaseHandlerTest.java
+++ b/cloudsoft-terraform-template/src/test/java/io/cloudsoft/terraform/template/TerraformBaseHandlerTest.java
@@ -1,0 +1,130 @@
+package io.cloudsoft.terraform.template;
+
+import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
+import com.amazonaws.cloudformation.proxy.Logger;
+import com.amazonaws.cloudformation.proxy.ProgressEvent;
+import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.io.ByteArrayInputStream;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TerraformBaseHandlerTest {
+
+    @Mock
+    private AmazonS3 amazonS3;
+
+    @BeforeEach
+    public void setup() {
+        amazonS3 = mock(AmazonS3.class);
+    }
+
+    @Test
+    public void getConfigurationReturnConfigurationContentProperty() {
+        final TerraformBaseHandlerUnderTest handler = new TerraformBaseHandlerUnderTest();
+        final String configurationContent = "Hello world";
+        final ResourceModel model = ResourceModel.builder().configurationContent(configurationContent).build();
+
+        String result = handler.getConfiguration(model);
+        assertEquals(configurationContent, result);
+    }
+
+    @Test
+    public void getConfigurationReturnsDownloadedConfigurationFromUrlProperty() {
+        final TerraformBaseHandlerUnderTest handler = new TerraformBaseHandlerUnderTest();
+        final String configurationUrl = "http://www.mocky.io/v2/5dc19cab33000051e91a5437";
+        final ResourceModel model = ResourceModel.builder().configurationUrl(configurationUrl).build();
+
+        String expected = "Hello world";
+        String result = handler.getConfiguration(model);
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void getConfigurationThrowsIfUrlDoesNotExistProperty() {
+        final TerraformBaseHandlerUnderTest handler = new TerraformBaseHandlerUnderTest();
+        final String configurationUrl = "http://acme.com/does/not/exist";
+        final ResourceModel model = ResourceModel.builder().configurationUrl(configurationUrl).build();
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            handler.getConfiguration(model);
+        });
+    }
+
+    @Test
+    public void getConfigurationReturnsDownloadedConfigurationFromS3PathProperty() {
+        final TerraformBaseHandlerUnderTest handler = new TerraformBaseHandlerUnderTest(amazonS3);
+        final String configurationS3Path = "s3://my-bucket/hello-world.txt";
+        final ResourceModel model = ResourceModel.builder().configurationS3Path(configurationS3Path).build();
+
+        final String expected = "Hello world";
+        final S3Object s3Object = new S3Object();
+        s3Object.setObjectContent(new ByteArrayInputStream(expected.getBytes()));
+        when(amazonS3.getObject(any())).thenReturn(s3Object);
+
+        String result = handler.getConfiguration(model);
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void getConfigurationThrowsIfS3PathIsInvalid() {
+        final TerraformBaseHandlerUnderTest handler = new TerraformBaseHandlerUnderTest();
+        final String configurationS3Path = "http://acme.com/does/not/exist";
+        final ResourceModel model = ResourceModel.builder().configurationS3Path(configurationS3Path).build();
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            handler.getConfiguration(model);
+        });
+    }
+
+    @Test
+    public void getConfigurationThrowsIfS3PathDoesNotExistProperty() {
+        final TerraformBaseHandlerUnderTest handler = new TerraformBaseHandlerUnderTest();
+        final String configurationS3Path = "s3://bucket/does/not/exist";
+        final ResourceModel model = ResourceModel.builder().configurationS3Path(configurationS3Path).build();
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            handler.getConfiguration(model);
+        });
+    }
+
+    @Test
+    public void getConfigurationThrowsIfNoProperties() {
+        final TerraformBaseHandlerUnderTest handler = new TerraformBaseHandlerUnderTest();
+        final ResourceModel model = ResourceModel.builder().build();
+
+        assertThrows(IllegalStateException.class, () -> {
+            handler.getConfiguration(model);
+        });
+    }
+
+    // TerraformBaseHandler is an abstract class. In order to tests methods within it, we need to create a dummy implementation
+    class TerraformBaseHandlerUnderTest extends TerraformBaseHandler<CallbackContext> {
+        public TerraformBaseHandlerUnderTest() {
+            super();
+        }
+
+        public TerraformBaseHandlerUnderTest(AmazonS3 amazonS3) {
+            super(amazonS3);
+        }
+
+        @Override
+        public ProgressEvent<ResourceModel, CallbackContext> handleRequest(AmazonWebServicesClientProxy proxy,
+                                                                           ResourceHandlerRequest<ResourceModel> request,
+                                                                           CallbackContext callbackContext, Logger logger) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This includes:
- inlined configuration
- from a public URL
- from a S3 path

This updates the schema to add 3 parameters. Only one of each is required at the time:
- `ConfigurationContent`
- `ConfigurationUrl`
- `ConfigurationS3Path`

https://www.pivotaltracker.com/story/show/169535422