### PR TITLE
Specified correct permissions to retrieve parameters and CFN configuration from S3

### DIFF
--- a/cloudsoft-terraform-template/cloudsoft-terraform-template.json
+++ b/cloudsoft-terraform-template/cloudsoft-terraform-template.json
@@ -38,27 +38,33 @@
   "handlers": {
     "create": {
       "permissions": [
-        "initech:CreateReport"
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "ssm:GetParameter"
       ]
     },
     "read": {
       "permissions": [
-        "initech:DescribeReport"
+        "ssm:GetParameter"
       ]
     },
     "update": {
       "permissions": [
-        "initech:UpdateReport"
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "ssm:GetParameter"
       ]
     },
     "delete": {
       "permissions": [
-        "initech:DeleteReport"
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "ssm:GetParameter"
       ]
     },
     "list": {
       "permissions": [
-        "initech:ListReports"
+        "ssm:GetParameter"
       ]
     }
   }

--- a/cloudsoft-terraform-template/resource-role.yaml
+++ b/cloudsoft-terraform-template/resource-role.yaml
@@ -23,11 +23,9 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                - initech:CreateReport
-                - initech:UpdateReport
-                - initech:DescribeReport
-                - initech:ListReports
-                - initech:DeleteReport
+                - "ssm:GetParameter"
+                - "s3:GetObject"
+                - "s3:GetObjectVersion"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:


### PR DESCRIPTION
Note that the  command `cfn-cli generate` generates the `resource-role.yml` file automatically from the schema