### PR TITLE
switch to SCP, accept configuration from different sources

### DIFF
--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/TerraformBaseHandler.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/TerraformBaseHandler.java
@@ -77,7 +77,7 @@ public abstract class TerraformBaseHandler<T> extends BaseHandler<T> {
         return getParameterResponse.parameter().value();
     }
 
-    protected String getConfiguration(AmazonWebServicesClientProxy proxy, ResourceModel model) {
+    public String getConfiguration(AmazonWebServicesClientProxy proxy, ResourceModel model) {
         if (model.getConfigurationContent() != null) {
             return model.getConfigurationContent();
         }

--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/TerraformInterfaceSSH.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/TerraformInterfaceSSH.java
@@ -4,8 +4,11 @@ import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.IOUtils;
 import net.schmizz.sshj.connection.channel.direct.Session;
+import net.schmizz.sshj.xfer.InMemorySourceFile;
+import software.amazon.awssdk.utils.StringInputStream;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 
 public class TerraformInterfaceSSH {
@@ -18,7 +21,12 @@ public class TerraformInterfaceSSH {
     // useful after parameters can be specified separately for each server).
     private static final String
             // TF_DATADIR must match the contents of the files in server-side-systemd/
-            TF_DATADIR = "~/tfdata",
+            // (at least as far as realpath(1) is concerned).
+            // sshj does not expand tilde to the remote user's home directory on the server
+            // (OpenSSH scp does that). Also neither any directory components nor the
+            // file name can be quoted (as in "/some/'work dir'/otherdir") because sshj
+            // fails to escape the quotes properly (again, works in OpenSSH).
+            TF_DATADIR = "/home/ubuntu/tfdata",
             TF_CONFFILENAME = "configuration.tf";
 
     public TerraformInterfaceSSH(TerraformBaseHandler<?> h, AmazonWebServicesClientProxy proxy, String templateName) {
@@ -30,8 +38,8 @@ public class TerraformInterfaceSSH {
         this.templateName = templateName;
     }
 
-    protected String getWorkdir() {
-        return String.format("%s/'%s'", TF_DATADIR, templateName);
+    private String getWorkdir() {
+        return String.format("%s/%s", TF_DATADIR, templateName);
     }
 
     public void onlyMkdir() throws IOException {
@@ -74,6 +82,40 @@ public class TerraformInterfaceSSH {
                 // do nothing
             }
             ssh.disconnect();
+        }
+    }
+
+    public void uploadConfiguration (String contents) throws IOException {
+        StringSourceFile src = new StringSourceFile(TF_CONFFILENAME, contents);
+        SSHClient ssh = new SSHClient();
+        ssh.addHostKeyVerifier(sshServerKeyFP);
+        ssh.connect(serverHostname, sshPort);
+        try {
+            ssh.authPublickey(sshUsername, new SSHClient().loadKeys(sshClientSecretKeyContents, null, null));
+            ssh.newSCPFileTransfer().upload(src, getWorkdir());
+        } finally {
+            ssh.disconnect();
+        }
+    }
+
+    private class StringSourceFile extends InMemorySourceFile {
+        private String name, contents;
+
+        StringSourceFile (String name, String contents){
+            this.name = name;
+            this.contents = contents;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public long getLength() {
+            return contents.length();
+        }
+
+        public InputStream getInputStream() {
+            return new StringInputStream(contents);
         }
     }
 }

--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/worker/AbstractHandlerWorker.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/worker/AbstractHandlerWorker.java
@@ -6,6 +6,7 @@ import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
 import io.cloudsoft.terraform.template.*;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
@@ -72,5 +73,9 @@ public abstract class AbstractHandlerWorker {
         PrintWriter pw = new PrintWriter(sw);
         e.printStackTrace(pw);
         logger.log(origin + " error: " + e + "\n" + sw.toString());
+    }
+
+    void getAndUploadConfiguration() throws IOException {
+        tfSync.uploadConfiguration(handler.getConfiguration(proxy, model));
     }
 }

--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/worker/CreateHandlerWorker.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/worker/CreateHandlerWorker.java
@@ -16,7 +16,7 @@ public class CreateHandlerWorker extends AbstractHandlerWorker {
     public enum Steps {
         CREATE_INIT,
         CREATE_SYNC_MKDIR,
-        CREATE_SYNC_DOWNLOAD,
+        CREATE_SYNC_UPLOAD,
         CREATE_ASYNC_TF_INIT,
         CREATE_ASYNC_TF_APPLY,
         CREATE_DONE
@@ -44,10 +44,10 @@ public class CreateHandlerWorker extends AbstractHandlerWorker {
                     tfSync.onlyMkdir();
                     break;
                 case CREATE_SYNC_MKDIR:
-                    advanceTo(Steps.CREATE_SYNC_DOWNLOAD);
-                    tfSync.onlyDownload(model.getConfigurationUrl());
+                    advanceTo(Steps.CREATE_SYNC_UPLOAD);
+                    getAndUploadConfiguration();
                     break;
-                case CREATE_SYNC_DOWNLOAD:
+                case CREATE_SYNC_UPLOAD:
                     advanceTo(Steps.CREATE_ASYNC_TF_INIT);
                     tfInit.start();
                     break;

--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/worker/UpdateHandlerWorker.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/worker/UpdateHandlerWorker.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 public class UpdateHandlerWorker extends AbstractHandlerWorker {
     public enum Steps {
         UPDATE_INIT,
-        UPDATE_SYNC_DOWNLOAD,
+        UPDATE_SYNC_UPLOAD,
         UPDATE_ASYNC_TF_APPLY,
         UPDATE_DONE
     }
@@ -37,10 +37,10 @@ public class UpdateHandlerWorker extends AbstractHandlerWorker {
             RemoteSystemdUnit tfApply = new RemoteSystemdUnit(this.handler, this.proxy, "terraform-apply", model.getName());
             switch (curStep) {
                 case UPDATE_INIT:
-                    advanceTo(Steps.UPDATE_SYNC_DOWNLOAD);
-                    tfSync.onlyDownload(model.getConfigurationUrl());
+                    advanceTo(Steps.UPDATE_SYNC_UPLOAD);
+                    getAndUploadConfiguration();
                     break;
-                case UPDATE_SYNC_DOWNLOAD:
+                case UPDATE_SYNC_UPLOAD:
                     advanceTo(Steps.UPDATE_ASYNC_TF_APPLY);
                     tfApply.start();
                     break;


### PR DESCRIPTION
This code works with SAM tests like below:
```json
		"desiredResourceState": {
			"Name": "example10",
			"ConfigurationContent": "provider \"aws\" {\nregion = \"eu-central-1\"\n}\nresource \"aws_s3_bucket\" \"bucket1\" {\nbucket = \"denis-example10-bucket1\"\nacl    = \"private\"\n}\n"
		},
```