### PR TITLE
Remove hardcoded path

### DIFF
--- a/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/TerraformInterfaceSSH.java
+++ b/cloudsoft-terraform-template/src/main/java/io/cloudsoft/terraform/template/TerraformInterfaceSSH.java
@@ -71,7 +71,11 @@ public class TerraformInterfaceSSH {
     }
 
     public void onlyRmdir() throws IOException {
-        runSSHCommand("rm -rf " + getWorkdir());
+        onlyRmdir(getWorkdir());
+    }
+
+    public void onlyRmdir(String dir) throws IOException {
+        runSSHCommand("rm -rf " + dir);
     }
 
     protected void debug(String message) {
@@ -143,6 +147,7 @@ public class TerraformInterfaceSSH {
             ssh.newSCPFileTransfer().upload(src, getScpDir());
             // TODO: If ZIP or TAR archive, then expand in getScpDir(). The move will take care of the rest
             onlyMv(getScpDir() + "/*", getWorkdir() + "/" + src.getName());
+            onlyRmdir(getScpDir());
         } finally {
             try {
                 ssh.disconnect();


### PR DESCRIPTION
This removes the hardcoded `/home/ubuntu` and goes back to use `~`. However, scp doesn't expand `~` so to work around this, scp downloads first the file to `/tmp/<UUID>/configuration.tf`, then move it to the working directory (because the shell expand `~`) 