### PR TITLE
Add jitpack.io repo to avoid build failure on certain configuration

### DIFF
--- a/cloudsoft-terraform-template/pom.xml
+++ b/cloudsoft-terraform-template/pom.xml
@@ -23,6 +23,10 @@
             <id>central</id>
             <url>http://central.maven.org/maven2</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencyManagement>


### PR DESCRIPTION
On bare maven configuration, the dependency `com.github.everit-org.json-schema:org.everit.json.schema:jar:1.11.0` cannot be downloaded as it is not present on maven central, but jitpack.io. 

This makes sure the dependency, introduced by the latest RPDK plugin, can be downloaded