### PR TITLE
Improve CI/CD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up CFN CLI
       run: pip3 install cloudformation-cli cloudformation-cli-java-plugin
     - name: Set up nightly version
-      if: github.event_name == 'schedule'
+      if: github.event_name == 'schedule' && startsWith(github.repository, 'cloudsoft')
       run: |
         CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         NEW_VERSION=$(echo $CURRENT_VERSION | grep -E -o "[^-SNAPSHOT]+")-$(date '+%Y%m%d-%H%M%S')
@@ -45,10 +45,10 @@ jobs:
         AWS_REGION: eu-west-1
     # TODO: Add SAM tests when building nightly
     - name: Package nightly
-      if: github.event_name == 'schedule'
+      if: github.event_name == 'schedule' && startsWith(github.repository, 'cloudsoft')
       run: cfn submit --dry-run
     - name: Publish nightly
-      if: github.event_name == 'schedule'
+      if: github.event_name == 'schedule' && startsWith(github.repository, 'cloudsoft')
       uses: ncipollo/release-action@v1
       with:
         body: Automatic nightly release, made by GitHub actions


### PR DESCRIPTION
This does the following:
- Change the project version during nightly builds:
  - remove `-SNAPSHOT`, if any
  - append the current timestamp with the format `YYYYmmdd-HHmmssSSS`
  - set this in the `pom.xml` and for the release tag
- Restrict nightly release to `cloudsoft` org only, so it doesn't pollute forks