### PR TITLE
support a `*` in the log bucket name which will become the model identifier

### DIFF
--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -93,7 +93,7 @@ This resource provider (RP) uses the following parameters:
         
    - `/cfn/terraform/logs-s3-bucket-name` (optional): if set, all Terraform logs are shipped to an S3
      bucket and returned in output and in error messages.
-     This value value is as per the `LogBucketName` property on the resource;
+     This value is as per the `LogBucketName` property on the resource;
      see the documentation on that property in the [user-guide.md].
      If that property is set it will override any value set here.
 

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -91,9 +91,11 @@ This resource provider (RP) uses the following parameters:
      must run a Linux distribution that uses systemd with support for user mode and linger
      (typically CentOS 8, Fedora 28+, Ubuntu 18.04+, but not Amazon Linux 2)
         
-   - `/cfn/terraform/logs-s3-bucket-prefix` (optional): if set, all Terraform logs are shipped to an S3
-     bucket created as part of the stack and returned to the user as a URL on success;
-     note this can be overridden by the user with a property on the resource (see the [user-guide.md])
+   - `/cfn/terraform/logs-s3-bucket-name` (optional): if set, all Terraform logs are shipped to an S3
+     bucket and returned in output and in error messages.
+     This value value is as per the `LogBucketName` property on the resource;
+     see the documentation on that property in the [user-guide.md].
+     If that property is set it will override any value set here.
 
 Where a parameter is optional, it can be omitted or the special value `default` can be set to tell the RP
 to use the default value.  Note that omitting it causes warnings in the CloudWatch logs 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -48,7 +48,7 @@ Properties:
 | `ConfigurationUrl` | Public HTTP URL of a Terraform configuration. This will be downloaded from within CloudFormation and uploaded to the Terraform server. | (as above) |
 | `ConfigurationS3Path` | S3 path object representing a Terraform configuration. The current account must have access to this resource. This will be downloaded from within CloudFormation and uploaded to the Terraform server. | (as above) |
 | `Variables` | Variables to make available to the Terraform configuration by means of an `.auto.tfvars.json` file. | Optional in the CloudFormation template, although may be required by the Terraform configuration. |
-| `LogBucketName` | The name of an S3 bucket to create (if not present) and write log files | Optional; useful if the Terraform is not behaving as expected |
+| `LogBucketName` | The name of an S3 bucket to create (if not present) and write log files. This property value can contain a `*` character which will be replaced by the model's identifier, ensuring creation of a new bucket for each stack which the user will have access to. If the value does not contain `*` the bucket should either be intended for a single user or else manually configured with appropriate permissions for all users to see and for this resource provider to write to, otherwise the bucket may be unusable or inaccessible to some.  Restrictions on bucket names apply (between 3 and 63 characters long, no capital letters, etc). | Optional; useful if the Terraform is not behaving as expected |
 
 ## Return Values
 
@@ -58,7 +58,7 @@ The resource provider will set the following outputs on the resource.
 |-----|------|-------------|
 | `Outputs` | Object | All output coming from the Terraform configuration, as a map. |
 | `OutputsStringified` | String | All output coming from the Terraform configuration, as a JSON string of the map. |
-| `LogBucketUrl` | String | A URL where logs can be found (if the property or RP configuration is set). Note that this is only set if a log bucket is explicitly requested either with the `LogBucketName` property in CFN or a `/cfn/terraform/logs-s3-bucket-prefix` parameter in SSM. |
+| `LogBucketUrl` | String | A URL where logs can be found if S3 logs are configured. Note that this is only set if a log bucket is explicitly requested, either with the `LogBucketName` property in CFN or a `/cfn/terraform/logs-s3-bucket-name` parameter in SSM. |
 
 You can use the `Fn::GetAtt` intrinsic function to access these values,
 e.g. in the `Outputs` section of your CloudFormation to set an output on the stack and see it. 

--- a/setup.yaml
+++ b/setup.yaml
@@ -88,15 +88,19 @@ Resources:
       Name: /cfn/terraform/process-manager
       Type: String
       Value: 'nohup'
-  TerraformLogsS3BucketPrefix:
+  TerraformLogsS3BucketName:
     Type: AWS::SSM::Parameter
     Properties:
       Description: |
-        Prefix to use when creating log buckets.
-        Any value other than "default" will result in a bucket being created for each CFN resource created by this provider,
+        Optional bucket where all Terraform logs will be shipped.
+        Any value other than "default" will result in a bucket being created as necessary and logs copied to it,
         so that the user can easily inspect the logs (without needing special CloudWatch access).
-        A hyphen and the model identifier will be appended.
-      Name: /cfn/terraform/logs-s3-bucket-prefix
+        This parameter value can contain a * character which will be replaced by the model's identifier,
+        ensuring creation of a new bucket for each run which the user will have access to but other users will not.
+        If the value does not contain * the bucket should be created ahead of time with appropriate permissions for 
+        users to see and for this resource provider to write to, otherwise the bucket may be unusable or inaccessible to some users.  
+        Note this can be overridden by the user with a property on the resource (see the user guide).
+      Name: /cfn/terraform/logs-s3-bucket-name
       Type: String
       Value: 'default'
 
@@ -125,6 +129,6 @@ Outputs:
   TerraformProcessManagerParameter:
     Value:
       Ref: TerraformProcessManagerParameter
-  TerraformLogsS3BucketPrefix:
+  TerraformLogsS3BucketName:
     Value:
-      Ref: TerraformLogsS3BucketPrefix
+      Ref: TerraformLogsS3BucketName

--- a/src/main/java/io/cloudsoft/terraform/infrastructure/ConnectorHandlerFailures.java
+++ b/src/main/java/io/cloudsoft/terraform/infrastructure/ConnectorHandlerFailures.java
@@ -1,5 +1,7 @@
 package io.cloudsoft.terraform.infrastructure;
 
+import com.google.common.base.Strings;
+
 /** Unchecked exceptions indicating a handler request should fail.
  * These are used primarily to ensure an appropriate level of logging to the consumer.
  */
@@ -38,6 +40,13 @@ public class ConnectorHandlerFailures {
         protected Unhandled(String message, Throwable cause) {
             super(message, cause);
         }
+    }
+
+    /** Return a simple message, viz. the Exception.getMessage if non-blank (dropping the exception class), otherwise a toString */
+    public static String simpleMessage(Exception e) {
+        if (e==null) return "No details";
+        if (Strings.isNullOrEmpty(e.getMessage())) return e.toString();
+        return e.getMessage();
     }
 
 

--- a/src/main/java/io/cloudsoft/terraform/infrastructure/CreateHandler.java
+++ b/src/main/java/io/cloudsoft/terraform/infrastructure/CreateHandler.java
@@ -84,6 +84,7 @@ public class CreateHandler extends TerraformBaseHandler {
                                 setModelLogBucketUrlFromCallbackContextName();
                             } catch (Exception e) {
                                 log(String.format("Failed to createlog bucket %s: %s (%s)", logBucketName, e.getClass().getName(), e.getMessage()));
+                                callbackContext.logBucketName = null;
                                 throw ConnectorHandlerFailures.handled("Unable to initialize log bucket; either the bucket is not creatable or not writeable: "+ConnectorHandlerFailures.simpleMessage(e));
                             }
                         }

--- a/src/main/java/io/cloudsoft/terraform/infrastructure/TerraformBaseWorker.java
+++ b/src/main/java/io/cloudsoft/terraform/infrastructure/TerraformBaseWorker.java
@@ -476,7 +476,14 @@ public abstract class TerraformBaseWorker<Steps extends Enum<Steps>> {
     }
 
     private String getLogFileObjectKey(String objectSuffix) {
-        return (model.getLogBucketName()!=null ? model.getIdentifier()+"/" : "") + callbackContext.getCommandRequestId()+"-"+getCommandSummary()+"/"+objectSuffix;
+        String folder;
+        if (callbackContext.getLogBucketName().contains(model.getIdentifier().toLowerCase())) {
+            folder = "";
+        } else {
+            // put in a virtual subfolder unless the bucket name already contains the model identifier 
+            folder = model.getIdentifier()+"/";
+        }
+        return folder + callbackContext.getCommandRequestId()+"-"+getCommandSummary()+"/"+objectSuffix;
     }
     protected boolean uploadCompleteLog(String objectSuffix, String text) {
         String bucketName = callbackContext.getLogBucketName();

--- a/src/main/java/io/cloudsoft/terraform/infrastructure/TerraformParameters.java
+++ b/src/main/java/io/cloudsoft/terraform/infrastructure/TerraformParameters.java
@@ -91,8 +91,8 @@ public class TerraformParameters {
         return fp;
     }
 
-    public String getLogsS3BucketPrefix() {
-        String bp = getParameterValue("logs-s3-bucket-prefix", false);
+    public String getLogsS3BucketName() {
+        String bp = getParameterValue("logs-s3-bucket-name", false);
         if (isDefault(bp)) {
             return null;
         }

--- a/src/test/java/io/cloudsoft/terraform/infrastructure/HandlerTestFixture.java
+++ b/src/test/java/io/cloudsoft/terraform/infrastructure/HandlerTestFixture.java
@@ -80,7 +80,7 @@ public class HandlerTestFixture {
         return new TerraformParameters(logger, proxy, ssmClient, s3Client) {
             // this one is read during init
             @Override
-            public String getLogsS3BucketPrefix() {
+            public String getLogsS3BucketName() {
                 return null;
             }
         };


### PR DESCRIPTION
change the "prefix" ssm param to "name".  this allows the ssm config to specify a fixed bucket,
and allows cfn config to specify a dynamic bucket.